### PR TITLE
Split logic for support windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossterm"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "fastkill"
 version = "1.0.0"
 dependencies = [
@@ -69,6 +124,15 @@ dependencies = [
  "regex",
  "sysinfo",
  "unicode-width",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -125,6 +189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +214,25 @@ name = "newline-converter"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f81c2b19eebbc4249b3ca6aff70ae05bf18d6a99b7cc63cf0248774e640565"
+
+[[package]]
+name = "ntapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -187,6 +279,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -270,11 +386,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.3.19"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953067ed3a538fd8e5fe4a6b4ddbbdedd348a3421f8a3b2aa97f2ca06f8ea57e"
+checksum = "7890fff842b8db56f2033ebee8f6efe1921475c3830c115995552914fb967580"
 dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
  "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "fastkill"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "inquire",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 
 [dependencies]
 inquire = "0.4.0"
-sysinfo = "0.3.15"
+sysinfo = "0.26.4"
 regex = "1.6.0"
 once_cell = "1"
 unicode-width = "0.1.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,94 +1,13 @@
-use std::collections::HashMap;
+use inquire::{InquireError, Select};
+use sysinfo::ProcessExt;
 
-use inquire::{error::InquireError, Select};
-use once_cell::sync::Lazy;
-use regex::Regex;
-use std::process::Command;
-use sysinfo::{Process, System, SystemExt};
-use unicode_width::UnicodeWidthStr;
+use crate::process::ProcessInfo;
 
-static REGEX_WHITE_SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
-static SYSTEM: Lazy<System> = Lazy::new(|| {
-    let mut sys = System::new();
-    sys.refresh_all();
-    sys
-});
-
-struct PortInfo {
-    protocol: String,
-    port: u16,
-}
-
-impl std::fmt::Display for PortInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.protocol)?;
-        f.write_str(":")?;
-        f.write_fmt(format_args!("{}", self.port))
-    }
-}
-
-struct ProcessInfo<'a> {
-    process: &'a Process,
-    ports: Vec<PortInfo>,
-}
-
-impl<'a> std::fmt::Display for ProcessInfo<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let prefix_space_count = 35usize.saturating_sub(self.process.name.width_cjk());
-        let prefix = " ".repeat(prefix_space_count);
-
-        f.write_fmt(format_args!(
-            "{:>8} | {prefix}{} | CPU {:>5.2} | MEM {:>5.0}MB | ",
-            self.process.pid,
-            self.process.name,
-            self.process.cpu_usage,
-            self.process.memory / 1024,
-        ))?;
-
-        for port in &self.ports {
-            f.write_fmt(format_args!("{} ", port))?;
-        }
-
-        Ok(())
-    }
-}
-
-fn try_parse_lsof_line(line: &str) -> Option<(i32, PortInfo)> {
-    let parts: Vec<_> = REGEX_WHITE_SPACES.split(line).collect();
-    let pid = parts.get(1)?.parse().ok()?;
-    let protocol = parts.get(7)?.to_string();
-    let port = parts.get(8)?.split(':').nth(1)?.parse().ok()?;
-    let port_info = PortInfo { protocol, port };
-    Some((pid, port_info))
-}
-
-fn get_pid_port_table() -> HashMap<i32, Vec<PortInfo>> {
-    let output = Command::new("lsof")
-        .args(&["-nP"])
-        .output()
-        .expect("Failed to execute lsof");
-
-    let output = String::from_utf8_lossy(&output.stdout);
-    let mut table: HashMap<i32, Vec<PortInfo>> = HashMap::new();
-
-    output
-        .lines()
-        .filter(|line| line.contains("LISTEN"))
-        .flat_map(try_parse_lsof_line)
-        .for_each(|(pid, port)| {
-            table.entry(pid).or_default().push(port);
-        });
-
-    table
-}
-
-fn kill_process_by_pid(pid: i32) {
-    Command::new("kill")
-        .arg("-9")
-        .arg(pid.to_string())
-        .spawn()
-        .unwrap();
-}
+mod process;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod unix;
+#[cfg(target_os = "windows")]
+mod windows;
 
 struct App {}
 
@@ -97,32 +16,17 @@ impl App {
         Self {}
     }
 
-    fn get_options(&mut self) -> Vec<ProcessInfo<'static>> {
-        let list = SYSTEM.get_process_list();
-        let mut table = get_pid_port_table();
-
-        let mut process_list = list.values().collect::<Vec<&Process>>();
-        process_list.sort_by(|a, b| a.cpu_usage.total_cmp(&b.cpu_usage));
-
-        process_list
-            .into_iter()
-            .map(|process| {
-                let ports = table.remove(&process.pid).unwrap_or_default();
-                ProcessInfo { process, ports }
-            })
-            .collect()
-    }
-
     pub fn start(&mut self) {
-        let options = self.get_options();
+        let options = process::get_process_list();
         let ans: Result<ProcessInfo<'static>, InquireError> =
             Select::new("Select process to kill:", options).prompt();
         match ans {
             Ok(choice) => {
-                kill_process_by_pid(choice.process.pid);
+                choice.process.kill();
                 println!(
                     "Process {}({}) killed.",
-                    choice.process.name, choice.process.pid
+                    choice.process.name(),
+                    choice.process.pid()
                 )
             }
             Err(InquireError::OperationCanceled | InquireError::OperationInterrupted) => (),

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,71 @@
+use std::cmp::Reverse;
+
+use once_cell::sync::Lazy;
+use sysinfo::{Process, ProcessExt, System, SystemExt};
+use unicode_width::UnicodeWidthStr;
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use crate::unix as os;
+#[cfg(any(target_os = "windows"))]
+use crate::windows as os;
+
+static SYSTEM: Lazy<System> = Lazy::new(|| {
+    let mut sys = System::new();
+    sys.refresh_all();
+    sys
+});
+
+pub struct PortInfo {
+    pub protocol: String,
+    pub port: u16,
+}
+
+impl std::fmt::Display for PortInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.protocol)?;
+        f.write_str(":")?;
+        f.write_fmt(format_args!("{}", self.port))
+    }
+}
+
+pub struct ProcessInfo<'a> {
+    pub process: &'a Process,
+    pub ports: Vec<PortInfo>,
+}
+
+impl<'a> std::fmt::Display for ProcessInfo<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let prefix_space_count = 35usize.saturating_sub(self.process.name().width_cjk());
+        let prefix = " ".repeat(prefix_space_count);
+
+        f.write_fmt(format_args!(
+            "{:>8} | {prefix}{} | CPU {:>6.2}% | MEM {:>5.0}MB | ",
+            self.process.pid().to_string(),
+            self.process.name(),
+            self.process.cpu_usage(),
+            self.process.memory() / 1024 / 1024,
+        ))?;
+
+        for port in &self.ports {
+            f.write_fmt(format_args!("{} ", port))?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn get_process_list() -> Vec<ProcessInfo<'static>> {
+    let list = SYSTEM.processes();
+    let mut table = os::get_pid_port_table();
+
+    let mut process_list = list.values().collect::<Vec<&Process>>();
+    process_list.sort_by_key(|p| Reverse((p.cpu_usage() * 100.0) as u32));
+
+    process_list
+        .into_iter()
+        .map(|process| {
+            let ports = table.remove(&process.pid()).unwrap_or_default();
+            ProcessInfo { process, ports }
+        })
+        .collect()
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,39 @@
+use std::collections::HashMap;
+use std::process::Command;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use sysinfo::Pid;
+
+use crate::process::PortInfo;
+
+static REGEX_WHITE_SPACES: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
+
+fn try_parse_lsof_line(line: &str) -> Option<(Pid, PortInfo)> {
+    let parts: Vec<_> = REGEX_WHITE_SPACES.split(line).collect();
+    let pid = parts.get(1)?.parse().ok()?;
+    let protocol = parts.get(7)?.to_string();
+    let port = parts.get(8)?.split(':').nth(1)?.parse().ok()?;
+    let port_info = PortInfo { protocol, port };
+    Some((pid, port_info))
+}
+
+pub fn get_pid_port_table() -> HashMap<Pid, Vec<PortInfo>> {
+    let output = Command::new("lsof")
+        .args(&["-nP"])
+        .output()
+        .expect("Failed to execute lsof");
+
+    let output = String::from_utf8_lossy(&output.stdout);
+    let mut table: HashMap<Pid, Vec<PortInfo>> = HashMap::new();
+
+    output
+        .lines()
+        .filter(|line| line.contains("LISTEN"))
+        .filter_map(try_parse_lsof_line)
+        .for_each(|(pid, port)| {
+            table.entry(pid).or_default().push(port);
+        });
+
+    table
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,10 @@
+use std::collections::HashMap;
+
+use sysinfo::Pid;
+
+use crate::process::PortInfo;
+
+pub fn get_pid_port_table() -> HashMap<Pid, Vec<PortInfo>> {
+    // TODO: Get process listening ports for Windows use Winapi.
+    HashMap::new()
+}


### PR DESCRIPTION
Just split file, add cfg compile for different os.

Add init support for windows, no port info, but other staff(pid, process name, cpu, memory) works.