### PR TITLE
feat(windows): show tcp ports info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,13 +117,14 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "fastkill"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "inquire",
  "once_cell",
  "regex",
  "sysinfo",
  "unicode-width",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ sysinfo = "0.26.4"
 regex = "1.6.0"
 once_cell = "1"
 unicode-width = "0.1.10"
+
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["iphlpapi", "tcpmib", "minwindef", "winsock2"] }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,10 +1,138 @@
-use std::collections::HashMap;
+use std::{alloc::Layout, collections::HashMap};
 
 use sysinfo::Pid;
 
 use crate::process::PortInfo;
 
+trait Table<T> {
+    fn table(&self) -> *const T;
+    fn row_count(&self) -> usize;
+}
+
+trait Row {
+    fn pid(&self) -> u32;
+    fn state(&self) -> u32;
+    fn port(&self) -> u32;
+}
+
+trait Protocol<T: Row>: Table<T> + Default {
+    fn name() -> &'static str;
+    fn win32_api(table: *mut Self, size: *mut u32) -> u32;
+    fn listening_ports() -> HashMap<Pid, Vec<PortInfo>> {
+        let mut table = Self::default();
+        let mut table_ptr = &mut table as *mut Self;
+        let mut size: winapi::ctypes::c_ulong = 0;
+        let size_ptr = &mut size as winapi::shared::minwindef::PULONG;
+        let code = Self::win32_api(table_ptr, size_ptr);
+
+        let buff;
+        if code == winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER {
+            buff =
+                unsafe { std::alloc::alloc(Layout::from_size_align_unchecked(size as usize, 1)) };
+            if buff.is_null() {
+                panic!("get listening port list size of protocol {} failed: memory not enough, {} bytes needed", Self::name(), size);
+            }
+            table_ptr = buff as *mut Self;
+        } else {
+            panic!(
+                "get listening port list size of protocol {} failed: {}",
+                Self::name(),
+                code
+            );
+        }
+
+        let code = Self::win32_api(table_ptr, size_ptr);
+
+        if code != winapi::shared::winerror::NO_ERROR {
+            panic!(
+                "get listening port list of protocol {} failed: {}",
+                Self::name(),
+                code
+            );
+        }
+
+        let table: &mut Self = unsafe { &mut *table_ptr };
+        let rows = unsafe { std::slice::from_raw_parts(table.table(), table.row_count()) };
+
+        let mut result: HashMap<Pid, Vec<PortInfo>> = HashMap::new();
+
+        rows.iter()
+            .filter(|row| row.state() == winapi::shared::tcpmib::MIB_TCP_STATE_LISTEN)
+            .for_each(|row| {
+                result
+                    .entry(Pid::from(row.pid() as usize))
+                    .or_default()
+                    .push(PortInfo {
+                        protocol: Self::name().to_string(),
+                        port: unsafe {
+                            winapi::um::winsock2::ntohs(row.port() as winapi::um::winsock2::u_short)
+                        },
+                    });
+            });
+
+        result
+    }
+}
+
+macro_rules! protocol_impl {
+    (stateimpl, $self:ident, dwState) => {
+        $self.dwState
+    };
+
+    (stateimpl, $self:ident, State) => {
+        $self.State
+    };
+
+    ($name:literal = $func:path => $t:ty { $state:tt }: [$r:ty]) => {
+        impl Row for $r {
+            fn pid(&self) -> u32 {
+                self.dwOwningPid
+            }
+
+            fn state(&self) -> u32 {
+                protocol_impl!(stateimpl, self, $state)
+            }
+
+            fn port(&self) -> u32 {
+                self.dwLocalPort
+            }
+        }
+
+        impl Table<$r> for $t {
+            fn table(&self) -> *const $r {
+                self.table.as_ptr()
+            }
+
+            fn row_count(&self) -> usize {
+                self.dwNumEntries as usize
+            }
+        }
+        impl Protocol<$r> for $t {
+            fn name() -> &'static str {
+                $name
+            }
+
+            fn win32_api(table: *mut Self, size: *mut u32) -> u32 {
+                unsafe { $func(table, size, 0) }
+            }
+        }
+    };
+}
+
+protocol_impl!("TCP" = winapi::um::iphlpapi::GetTcpTable2 => winapi::shared::tcpmib::MIB_TCPTABLE2 { dwState }: [winapi::shared::tcpmib::MIB_TCPROW2]);
+protocol_impl!("TCP6" = winapi::um::iphlpapi::GetTcp6Table2 => winapi::shared::tcpmib::MIB_TCP6TABLE2 { State }: [winapi::shared::tcpmib::MIB_TCP6ROW2]);
+
+// TODO: UDP?
+
 pub fn get_pid_port_table() -> HashMap<Pid, Vec<PortInfo>> {
-    // TODO: Get process listening ports for Windows use Winapi.
-    HashMap::new()
+    let mut result: HashMap<Pid, Vec<PortInfo>> = HashMap::new();
+
+    std::iter::empty()
+        .chain(winapi::shared::tcpmib::MIB_TCPTABLE2::listening_ports())
+        .chain(winapi::shared::tcpmib::MIB_TCP6TABLE2::listening_ports())
+        .for_each(|(pid, ports)| {
+            result.entry(pid).or_default().extend(ports.into_iter());
+        });
+
+    result
 }


### PR DESCRIPTION
By using win32 api [`GetTcpTable2`](https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-gettcptable2) and [`GetTcp6Table2`](https://learn.microsoft.com/en-us/windows/win32/api/iphlpapi/nf-iphlpapi-gettcp6table2), so it adds many unsafe code...

Screenshot: 

![图片](https://user-images.githubusercontent.com/7822577/195694206-6d5c22d1-d6ef-4b27-8427-574f54a3cabe.png)

Not carefully tested, but *works on my machine*...

![图片](https://user-images.githubusercontent.com/7822577/195695290-41f71eca-ad58-4553-b218-edf6f23945e6.png)
